### PR TITLE
fix: resolve white screen issue in Spectrum mode

### DIFF
--- a/packages/ColorWheel.vue
+++ b/packages/ColorWheel.vue
@@ -79,9 +79,12 @@
       ref="canvasRef"
       v-if="wheel === 'spectrum'"
       :style="{
-        width: '100%',
-        height: '100%',
-        borderRadius: '9999px',
+        position: 'absolute',
+        top: '0',
+        left: '0',
+        width: `${radius * 2}px`,
+        height: `${radius * 2}px`,
+        borderRadius: '50%',
         zIndex: '10'
       }"
     />


### PR DESCRIPTION
### Description

This pull request addresses an issue where selecting the "Spectrum" mode in the `vue-color-wheel` component results in a white screen.

#### Problem

In "Spectrum" mode, the canvas intended to display the HSV color wheel wasn't rendering correctly, leading to a blank (white) display.

#### Cause

The canvas element lacked explicit positioning and sizing, which caused it to be hidden or improperly rendered within the component's layout.

#### Solution

The canvas element's inline styles have been updated to ensure proper rendering:

```vue
<canvas
  ref="canvasRef"
  v-if="wheel === 'spectrum'"
  :style="{
    position: 'absolute',
    top: '0',
    left: '0',
    width: `${radius * 2}px`,
    height: `${radius * 2}px`,
    borderRadius: '50%',
    zIndex: '10'
  }"
/>
```


These changes ensure that the canvas is correctly positioned and sized within the component, allowing the HSV color wheel to render as intended.
